### PR TITLE
feat: Add logic to retry connection.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 build: ## Build containers
+	rm -f dist/*.whl
 	hatch dep show requirements > requirements.txt
 	hatch build
 	docker build -t "tsolo/cycax-blender-worker:${shell hatch version}" .

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+    command: /app/src/start.sh
     env_file: .env
     environment:
       - DEVELOPMENT=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = ["mypy==1.15.0", "ruff==0.11.10", "typos==1.32.0"]
+dependencies = ["mypy==1.16.1", "ruff==0.12.0", "typos==1.33.1"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:src/cycax_blender_worker tests}"
 style = ["ruff check --fix {args:.}"]

--- a/src/cycax_blender_worker/__about__.py
+++ b/src/cycax_blender_worker/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.0.2"
+__version__ = "0.0.3rc0"

--- a/src/cycax_blender_worker/assembler.py
+++ b/src/cycax_blender_worker/assembler.py
@@ -143,4 +143,6 @@ class AssemblyBlender:
         part_path.mkdir(exist_ok=True)
         save_file = str(self._base_path / job_id / f"{self.name}.blend")
         bpy.ops.wm.save_as_mainfile(filepath=save_file)
-        self._client.upload_artifacts("blender", job_id, self.name, self._base_path, job_path=True)
+        self._client.upload_artifacts(
+            "blender", job_id, self.name, self._base_path, job_path=True, extensions_only="blender"
+        )

--- a/src/cycax_blender_worker/config.py
+++ b/src/cycax_blender_worker/config.py
@@ -9,5 +9,5 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Config(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="cycax_")
-    server: str
+    server: str = ""
     temp_dir: Path = Path("/tmp/cycax_blender_worker")  # noqa: S108

--- a/src/start.sh
+++ b/src/start.sh
@@ -3,5 +3,11 @@
 # SPDX-FileCopyrightText: 2025 Tsolo.io
 #
 # SPDX-License-Identifier: Apache-2.0
-
-python3 /app/src/cycax_blender_worker/main.py
+set -eu
+while true
+do
+    # Run in an endless loop.
+    # The blender drawings leave artifacts behind,
+    # A simple solution is to restart the service after every drawing.
+    python3 /app/src/cycax_blender_worker/main.py
+done


### PR DESCRIPTION
When I restart the CyCAx server the blender worker crashes.
This fix will make it sleep for 10 seconds and then try again.
This is also sometimes a problem when we startup all the cycax processes and the server is a bit slow to start, then blender worker does not connect and crash.

I tested this with a cycax server that I stop started.