### PR TITLE
Martin/restart after assembly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = ["mypy==1.15.0", "ruff==0.11.10", "typos==1.32.0"]
+dependencies = ["mypy==1.16.1", "ruff==0.12.0", "typos==1.33.1"]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:src/cycax_blender_worker tests}"
 style = ["ruff check --fix {args:.}"]

--- a/src/cycax_blender_worker/__about__.py
+++ b/src/cycax_blender_worker/__about__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.0.2"
+__version__ = "0.0.3rc0"

--- a/src/cycax_blender_worker/assembler.py
+++ b/src/cycax_blender_worker/assembler.py
@@ -143,4 +143,6 @@ class AssemblyBlender:
         part_path.mkdir(exist_ok=True)
         save_file = str(self._base_path / job_id / f"{self.name}.blend")
         bpy.ops.wm.save_as_mainfile(filepath=save_file)
-        self._client.upload_artifacts("blender", job_id, self.name, self._base_path, job_path=True)
+        self._client.upload_artifacts(
+            "blender", job_id, self.name, self._base_path, job_path=True, extensions_only="blender"
+        )

--- a/src/start.sh
+++ b/src/start.sh
@@ -3,5 +3,11 @@
 # SPDX-FileCopyrightText: 2025 Tsolo.io
 #
 # SPDX-License-Identifier: Apache-2.0
-
-python3 /app/src/cycax_blender_worker/main.py
+set -eu
+while true
+do
+    # Run in an endless loop.
+    # The blender drawings leave artifacts behind,
+    # A simple solution is to restart the service after every drawing.
+    python3 /app/src/cycax_blender_worker/main.py
+done


### PR DESCRIPTION
When creating subsequent assemblies bits of the previous drawing is always left.
This is a bit of a hack, exit the python and start it again after every assembly.
What is needed is a way to clear the workspace before we start, we had a similar issue before where the fresh workspace always had a small cube, we got rid of that be deleting the cube since we know its name, but finding all objects and delete them one at a time feels like more effort than exiting Python.